### PR TITLE
空白がある際に計算が空白の手前だけになってしまうバグの修正

### DIFF
--- a/shisoku.Integration/integration_calc.sh
+++ b/shisoku.Integration/integration_calc.sh
@@ -1,25 +1,35 @@
-set -eu
 function main(){
+    local exit_all=0
     run_test_case "足し算" 1+1 2 
+    exit_all=$((exit_all+$?))
     run_test_case "掛け算" 1*1 1 
+    exit_all=$((exit_all+$?))
     run_test_case "（）付きの計算式" "(1+1)*3" 6
+    exit_all=$((exit_all+$?))
     run_test_case "割算が優先" "1+6/3" 3
+    exit_all=$((exit_all+$?))
     #run_test_case "（）の後に（）が来ている" "(1+1)(3)" error
+    #exit_all=$((exit_all+$?))
     # なぜ上が正しくないかというとパースした後に全てのTokenが使い切れる構文木が生成されないから。 
     # Tokenが余っていたら弾く
     # TODO 本体コードを修正する
     run_test_case "空白は全て無視するよって正しい計算式が空白で区切られても問題ない" "1+1 +2" 4 
+    exit_all=$((exit_all+$?))
     run_test_case "(が終了していない" "(1+1" error
+    exit_all=$((exit_all+$?))
     run_test_case "文字列を入れると失敗する" "aaaa" error
+    exit_all=$((exit_all+$?))
     run_test_case "演算記号のみを入れると失敗する" "---" error
+    exit_all=$((exit_all+$?))
     run_test_case "演算記号のみを入れると失敗する" "1-2" -1 
-
+    exit_all=$((exit_all+$?))
+    return ${exit_all}
 }
 
 function run_test_case(){
-    local case_name=("$1")
-    local input=("$2")
-    local expected=("$3")
+    local case_name="$1"
+    local input="$2"
+    local expected="$3"
 
     local output
     output=$(dotnet run --no-build --project shisoku -- --exp "${input}" 2> /dev/null)

--- a/shisoku.Integration/integration_calc.sh
+++ b/shisoku.Integration/integration_calc.sh
@@ -5,7 +5,7 @@ function main(){
     run_test_case "割算が優先" "1+6/3" 3
     #run_test_case "（）の後に数字もしくは（）が来ている" "(1+1)(3)" error 
     # TODO 本体コードを修正する
-    #run_test_case "空白は全て無視するよって正しい計算式が空白で区切られても問題ない" "(1+1) +2" 4 
+    run_test_case "空白は全て無視するよって正しい計算式が空白で区切られても問題ない" "1+1 +2" 4 
     run_test_case "(が終了していない" "(1+1" error
     run_test_case "文字列を入れると失敗する" "aaaa" error
     run_test_case "演算記号のみを入れると失敗する" "---" error
@@ -28,7 +28,7 @@ function run_test_case(){
         echo "${case_name}:Pass"
         return 0
     else
-        echo "${case_name}:Fail" 
+        echo "${case_name}:Fail output is ${output}. Be ${expected}" 
         return 1
     fi
 }

--- a/shisoku.Integration/integration_calc.sh
+++ b/shisoku.Integration/integration_calc.sh
@@ -1,9 +1,12 @@
+set -eu
 function main(){
     run_test_case "足し算" 1+1 2 
     run_test_case "掛け算" 1*1 1 
     run_test_case "（）付きの計算式" "(1+1)*3" 6
     run_test_case "割算が優先" "1+6/3" 3
-    #run_test_case "（）の後に数字もしくは（）が来ている" "(1+1)(3)" error 
+    #run_test_case "（）の後に（）が来ている" "(1+1)(3)" error
+    # なぜ上が正しくないかというとパースした後に全てのTokenが使い切れる構文木が生成されないから。 
+    # Tokenが余っていたら弾く
     # TODO 本体コードを修正する
     run_test_case "空白は全て無視するよって正しい計算式が空白で区切られても問題ない" "1+1 +2" 4 
     run_test_case "(が終了していない" "(1+1" error

--- a/shisoku.Integration/integration_calc.sh
+++ b/shisoku.Integration/integration_calc.sh
@@ -1,30 +1,30 @@
 function main(){
-    local exit_all=0
+    local sum_exit_code=0
     run_test_case "足し算" 1+1 2 
-    exit_all=$((exit_all+$?))
+    sum_exit_code=$((sum_exit_code+$?))
     run_test_case "掛け算" 1*1 1 
-    exit_all=$((exit_all+$?))
+    sum_exit_code=$((sum_exit_code+$?))
     run_test_case "（）付きの計算式" "(1+1)*3" 6
-    exit_all=$((exit_all+$?))
+    sum_exit_code=$((sum_exit_code+$?))
     run_test_case "割算が優先" "1+6/3" 3
-    exit_all=$((exit_all+$?))
+    sum_exit_code=$((sum_exit_code+$?))
     #run_test_case "（）の後に（）が来ている" "(1+1)(3)" error
-    #exit_all=$((exit_all+$?))
+    #sum_exit_code=$((sum_exit_code+$?))
     # なぜ上が正しくないかというとパースした後に全てのTokenが使い切れる構文木が生成されないから。 
     # Tokenが余っていたら弾く
     # TODO 本体コードを修正する
     run_test_case "空白は全て無視するよって正しい計算式が空白で区切られても問題ない" "1+1 +2" 4 
-    exit_all=$((exit_all+$?))
+    sum_exit_code=$((sum_exit_code+$?))
     run_test_case "(が終了していない" "(1+1" error
-    exit_all=$((exit_all+$?))
+    sum_exit_code=$((sum_exit_code+$?))
     run_test_case "文字列を入れると失敗する" "aaaa" error
-    exit_all=$((exit_all+$?))
+    sum_exit_code=$((sum_exit_code+$?))
     run_test_case "演算記号のみを入れると失敗する" "---" error
-    exit_all=$((exit_all+$?))
+    sum_exit_code=$((sum_exit_code+$?))
     run_test_case "正解が負の数になっても失敗しない" "1-2" -1 
-    exit_all=$((exit_all+$?))
+    sum_exit_code=$((sum_exit_code+$?))
     
-    if [ ${exit_all} == "0" ];then
+    if [ ${sum_exit_code} == "0" ];then
         return 0
     else
         return 1
@@ -46,7 +46,7 @@ function run_test_case(){
         echo "${case_name}:Pass"
         return 0
     else
-        echo "${case_name}:Fail output is ${output}. Be ${expected}" 
+        echo "${case_name}:Fail output is ${output}. Shoud be ${expected}" 
         return 1
     fi
 }

--- a/shisoku.Integration/integration_calc.sh
+++ b/shisoku.Integration/integration_calc.sh
@@ -21,9 +21,14 @@ function main(){
     exit_all=$((exit_all+$?))
     run_test_case "演算記号のみを入れると失敗する" "---" error
     exit_all=$((exit_all+$?))
-    run_test_case "演算記号のみを入れると失敗する" "1-2" -1 
+    run_test_case "正解が負の数になっても失敗しない" "1-2" -1 
     exit_all=$((exit_all+$?))
-    return ${exit_all}
+    
+    if [ ${exit_all} == "0" ];then
+        return 0
+    else
+        return 1
+    fi 
 }
 
 function run_test_case(){

--- a/shisoku.Integration/integration_calc.sh
+++ b/shisoku.Integration/integration_calc.sh
@@ -14,12 +14,12 @@ function main(){
 }
 
 function run_test_case(){
-    local case_name=($1)
-    local input=($2)
-    local expected=($3)
+    local case_name=("$1")
+    local input=("$2")
+    local expected=("$3")
 
     local output
-    output=$(dotnet run --no-build --project shisoku -- --exp ${input} 2> /dev/null)
+    output=$(dotnet run --no-build --project shisoku -- --exp "${input}" 2> /dev/null)
     local error_code=$?
     if [ "${output}" = "${expected}" ];then
         echo "${case_name}:Pass"

--- a/shisoku.Tests/UnitTest1.cs
+++ b/shisoku.Tests/UnitTest1.cs
@@ -103,12 +103,4 @@ public class LexerTest
         var tokens = shisoku.Lexer.lex("12 + 12");
         Assert.Equal<Token>(teacher_token, tokens);
     }
-    public void lexInputSplitNumberWithWhitespace()
-    {
-        Assert.Throws<Exception>(() => shisoku.Lexer.lex("12 12"));
-    }
-    public void lexInputStartParenthesisAfterEndParenthesis()
-    {
-        Assert.Throws<Exception>(() => shisoku.Lexer.lex("(12+12)(12+12)"));
-    }
 }

--- a/shisoku.Tests/UnitTest1.cs
+++ b/shisoku.Tests/UnitTest1.cs
@@ -21,68 +21,68 @@ public class LexerTest
     [Fact]
     public void lexInputOnlyNumber()
     {
-        var teacherToken = new List<Token> {
+        var expectedToken = new List<Token> {
             new TokenNumber(12)
          };
         var tokens = shisoku.Lexer.lex("12");
-        Assert.Equal<Token>(teacherToken, tokens);
+        Assert.Equal<Token>(expectedToken, tokens);
 
     }
     [Fact]
     public void lexInputFirstNumberAndAdd()
     {
-        var teacherToken = new List<Token> {
+        var expectedToken = new List<Token> {
             new TokenNumber(12),
             new TokenPlus(),
             new TokenNumber(12)
         };
         var tokens = shisoku.Lexer.lex("12+12");
-        Assert.Equal<Token>(teacherToken, tokens);
+        Assert.Equal<Token>(expectedToken, tokens);
 
     }
     [Fact]
     public void lexInputFirstNumberAndSub()
     {
-        var teacherToken = new List<Token> {
+        var expectedToken = new List<Token> {
             new TokenNumber(12),
             new TokenMinus(),
             new TokenNumber(12)
          };
         var tokens = shisoku.Lexer.lex("12-12");
-        Assert.Equal<Token>(teacherToken, tokens);
+        Assert.Equal<Token>(expectedToken, tokens);
 
     }
     [Fact]
     public void lexInputFirstNumberAndMul()
     {
-        var teacherToken = new List<Token> {
+        var expectedToken = new List<Token> {
             new TokenNumber(12),
             new TokenAsterisk(),
             new TokenNumber(12)
         };
         var tokens = shisoku.Lexer.lex("12*12");
-        Assert.Equal<Token>(teacherToken, tokens);
+        Assert.Equal<Token>(expectedToken, tokens);
     }
     [Fact]
     public void lexInputFirstNumberAndDiv()
     {
-        var teacherToken = new List<Token> {
+        var expectedToken = new List<Token> {
             new TokenNumber(12),
             new TokenSlash(),
             new TokenNumber(12)
          };
         var tokens = shisoku.Lexer.lex("12/12");
-        Assert.Equal<Token>(teacherToken, tokens);
+        Assert.Equal<Token>(expectedToken, tokens);
     }
     [Fact]
     public void lexInputNotEndNumber()
     {
-        var teacherToken = new List<Token> {
+        var expectedToken = new List<Token> {
             new TokenNumber(12),
             new TokenSlash()
          };
         var tokens = shisoku.Lexer.lex("12/");
-        Assert.Equal<Token>(teacherToken, tokens);
+        Assert.Equal<Token>(expectedToken, tokens);
     }
     [Fact]
     public void lexInputOtherChars()
@@ -102,12 +102,12 @@ public class LexerTest
     [Fact]
     public void lexInputWithWhiteSpace()
     {
-        var teacherToken = new List<Token> {
+        var expectedToken = new List<Token> {
             new TokenNumber(12),
             new TokenPlus(),
             new TokenNumber(12)
          };
         var tokens = shisoku.Lexer.lex("12 + 12");
-        Assert.Equal<Token>(teacherToken, tokens);
+        Assert.Equal<Token>(expectedToken, tokens);
     }
 }

--- a/shisoku.Tests/UnitTest1.cs
+++ b/shisoku.Tests/UnitTest1.cs
@@ -21,62 +21,68 @@ public class LexerTest
     [Fact]
     public void lexInputOnlyNumber()
     {
-        var teacher_token = new List<Token> { };
-        teacher_token.Add(new TokenNumber(12));
+        var teacherToken = new List<Token> {
+            new TokenNumber(12)
+         };
         var tokens = shisoku.Lexer.lex("12");
-        Assert.Equal<Token>(teacher_token, tokens);
+        Assert.Equal<Token>(teacherToken, tokens);
 
     }
     [Fact]
     public void lexInputFirstNumberAndAdd()
     {
-        var teacher_token = new List<Token> { };
-        teacher_token.Add(new TokenNumber(12));
-        teacher_token.Add(new TokenPlus());
-        teacher_token.Add(new TokenNumber(12));
+        var teacherToken = new List<Token> {
+            new TokenNumber(12),
+            new TokenPlus(),
+            new TokenNumber(12)
+        };
         var tokens = shisoku.Lexer.lex("12+12");
-        Assert.Equal<Token>(teacher_token, tokens);
+        Assert.Equal<Token>(teacherToken, tokens);
 
     }
     [Fact]
     public void lexInputFirstNumberAndSub()
     {
-        var teacher_token = new List<Token> { };
-        teacher_token.Add(new TokenNumber(12));
-        teacher_token.Add(new TokenMinus());
-        teacher_token.Add(new TokenNumber(12));
+        var teacherToken = new List<Token> {
+            new TokenNumber(12),
+            new TokenMinus(),
+            new TokenNumber(12)
+         };
         var tokens = shisoku.Lexer.lex("12-12");
-        Assert.Equal<Token>(teacher_token, tokens);
+        Assert.Equal<Token>(teacherToken, tokens);
 
     }
     [Fact]
     public void lexInputFirstNumberAndMul()
     {
-        var teacher_token = new List<Token> { };
-        teacher_token.Add(new TokenNumber(12));
-        teacher_token.Add(new TokenAsterisk());
-        teacher_token.Add(new TokenNumber(12));
+        var teacherToken = new List<Token> {
+            new TokenNumber(12),
+            new TokenAsterisk(),
+            new TokenNumber(12)
+        };
         var tokens = shisoku.Lexer.lex("12*12");
-        Assert.Equal<Token>(teacher_token, tokens);
+        Assert.Equal<Token>(teacherToken, tokens);
     }
     [Fact]
     public void lexInputFirstNumberAndDiv()
     {
-        var teacher_token = new List<Token> { };
-        teacher_token.Add(new TokenNumber(12));
-        teacher_token.Add(new TokenSlash());
-        teacher_token.Add(new TokenNumber(12));
+        var teacherToken = new List<Token> {
+            new TokenNumber(12),
+            new TokenSlash(),
+            new TokenNumber(12)
+         };
         var tokens = shisoku.Lexer.lex("12/12");
-        Assert.Equal<Token>(teacher_token, tokens);
+        Assert.Equal<Token>(teacherToken, tokens);
     }
     [Fact]
     public void lexInputNotEndNumber()
     {
-        var teacher_token = new List<Token> { };
-        teacher_token.Add(new TokenNumber(12));
-        teacher_token.Add(new TokenSlash());
+        var teacherToken = new List<Token> {
+            new TokenNumber(12),
+            new TokenSlash()
+         };
         var tokens = shisoku.Lexer.lex("12/");
-        Assert.Equal<Token>(teacher_token, tokens);
+        Assert.Equal<Token>(teacherToken, tokens);
     }
     [Fact]
     public void lexInputOtherChars()
@@ -96,11 +102,12 @@ public class LexerTest
     [Fact]
     public void lexInputWithWhiteSpace()
     {
-        var teacher_token = new List<Token> { };
-        teacher_token.Add(new TokenNumber(12));
-        teacher_token.Add(new TokenPlus());
-        teacher_token.Add(new TokenNumber(12));
+        var teacherToken = new List<Token> {
+            new TokenNumber(12),
+            new TokenPlus(),
+            new TokenNumber(12)
+         };
         var tokens = shisoku.Lexer.lex("12 + 12");
-        Assert.Equal<Token>(teacher_token, tokens);
+        Assert.Equal<Token>(teacherToken, tokens);
     }
 }

--- a/shisoku.Tests/UnitTest1.cs
+++ b/shisoku.Tests/UnitTest1.cs
@@ -93,4 +93,22 @@ public class LexerTest
     {
         Assert.Throws<Exception>(() => shisoku.Lexer.lex("12a"));
     }
+    [Fact]
+    public void lexInputWithWhiteSpace()
+    {
+        var teacher_token = new List<Token> { };
+        teacher_token.Add(new TokenNumber(12));
+        teacher_token.Add(new TokenPlus());
+        teacher_token.Add(new TokenNumber(12));
+        var tokens = shisoku.Lexer.lex("12 + 12");
+        Assert.Equal<Token>(teacher_token, tokens);
+    }
+    public void lexInputSplitNumberWithWhitespace()
+    {
+        Assert.Throws<Exception>(() => shisoku.Lexer.lex("12 12"));
+    }
+    public void lexInputStartParenthesisAfterEndParenthesis()
+    {
+        Assert.Throws<Exception>(() => shisoku.Lexer.lex("(12+12)(12+12)"));
+    }
 }

--- a/shisoku/Lex.cs
+++ b/shisoku/Lex.cs
@@ -50,6 +50,10 @@ public class Lexer
                 input = input[(1)..];
 
             }
+            else if (input[0] == ' ')
+            {
+                input = input[(1)..];
+            }
             else if (input[0] - '0' >= 0 && input[0] - '0' < 10)
             {
                 (int target, int len) = lexInt(input);


### PR DESCRIPTION
バグの修正のためにASTの単体テストを追加で行う。