### PR TITLE
スペースや改行等の制御文字を無視する

### DIFF
--- a/shisoku.Tests/LexerTest.cs
+++ b/shisoku.Tests/LexerTest.cs
@@ -158,6 +158,17 @@ public class LexerTest
         var tokens = shisoku.Lexer.lex("=");
         Assert.Equal<Token>(expectedToken, tokens);
     }
+    [Fact]
+    public void lexInputTab()
+    {
+        var expectedToken = new List<Token> {
+            new TokenNumber(12),
+            new TokenPlus(),
+            new TokenNumber(12)
+         };
+        var tokens = shisoku.Lexer.lex("12\t+\t12");
+        Assert.Equal<Token>(expectedToken, tokens);
+    }
 
 
 }

--- a/shisoku.Tests/LexerTest.cs
+++ b/shisoku.Tests/LexerTest.cs
@@ -169,6 +169,16 @@ public class LexerTest
         var tokens = shisoku.Lexer.lex("12\t+\t12");
         Assert.Equal<Token>(expectedToken, tokens);
     }
+    [Fact]
+    public void lexInputNewLine()
+    {
+        var expectedToken = new List<Token> {
+            new TokenNumber(12),
+            new TokenPlus(),
+            new TokenNumber(12)
+         };
+        var tokens = shisoku.Lexer.lex("12\n+\n12");
+    }
 
 
 }

--- a/shisoku/Lex.cs
+++ b/shisoku/Lex.cs
@@ -41,15 +41,15 @@ public class Lexer
                 input = input[(1)..];
 
             }
-            else if (input[0] == ' ')
-            {
-                input = input[(1)..];
-            }
             else if (input[0] == '=')
             {
                 tokens.Add(new TokenEqual());
                 input = input[(1)..];
 
+            }
+            else if (Char.IsWhiteSpace(input[0]) || Char.IsControl(input[0]))
+            {
+                input = input[(1)..];
             }
             else if (Char.IsNumber(input[0]))
             {


### PR DESCRIPTION
#20 
スペースは、Linterの関心ではあるがLexer以下処理系の関心の対象に入れない。よって、余計な制御文字は無視する仕様とする。
尚、文字列の後の改行・スペースは区切りとして認識はできている。　