### PR TITLE
Return 式の定義

### DIFF
--- a/shisoku.Integration/integration_calc.sh
+++ b/shisoku.Integration/integration_calc.sh
@@ -26,10 +26,9 @@ function main() {
     sum_exit_code=$((sum_exit_code + $?))
     run_test_case "変数の定義をしても問題ない" "const a=1;" ""
     sum_exit_code=$((sum_exit_code + $?))
-    run_test_case "変数の計算をしても問題ない" "const a=1;a+1;" "2"
+    run_test_case "変数の計算をしても問題ない" "const a=1;a+1;" error
     sum_exit_code=$((sum_exit_code + $?))
-    run_test_case "複数の計算を出せる" "1-2;1;" "-1
-1"
+    run_test_case "複数の計算を出せる" "1-2;1;" error
     sum_exit_code=$((sum_exit_code + $?))
     run_test_case "Booleanが扱える" "1==1;" True
     sum_exit_code=$((sum_exit_code + $?))
@@ -58,7 +57,7 @@ function run_test_case() {
     if [ "${output}" = "${expected}" ]; then
         echo "${case_name}:Pass"
         return 0
-    elif [ ${expected} = "error" ] && [ ${error_code} -ne '0' ]; then
+    elif [ "${expected}" = "error" ] && [ "${error_code}" -ne '0' ]; then
         echo "${case_name}:Pass"
         return 0
     else

--- a/shisoku.Tests/CalcTest.cs
+++ b/shisoku.Tests/CalcTest.cs
@@ -125,4 +125,3 @@ public class CalcTest
         }
     }
 }
-Statemen

--- a/shisoku.Tests/CalcTest.cs
+++ b/shisoku.Tests/CalcTest.cs
@@ -125,3 +125,4 @@ public class CalcTest
         }
     }
 }
+Statemen

--- a/shisoku.Tests/ParserTest.cs
+++ b/shisoku.Tests/ParserTest.cs
@@ -252,6 +252,40 @@ public class ParserTest
         }
     }
     [Fact]
+    public void CanParseFunctionWithReturn()
+    {
+        var inputToken = new List<Token>{
+            new TokenCurlyBracketOpen(),
+            new TokenPipe(),
+            new TokenPipe(),
+            new TokenArrow(),
+            new TokenConst(),
+            new TokenIdentifier("test"),
+            new TokenEqual(),
+            new TokenNumber(12),
+            new TokenSemicolon(),
+            new TokenReturn(),
+            new TokenNumber(12),
+            new TokenCurlyBracketClose()
+        };
+        var expectedAst = new FunctionExpression(new List<string>(), new Statement[]{
+            new StatementConst("test", new NumberExpression(12)),
+            new StatementReturn(new NumberExpression(12))
+        });
+        (var result, _) = ParseExpression.parse(inputToken.ToArray());
+        switch (result)
+        {
+            case FunctionExpression(var arguments, var body):
+                Assert.Equal(expectedAst.body, body);
+                Assert.Equal(expectedAst.argumentNames, arguments);
+                break;
+
+            default:
+                Assert.Fail("result is not make FunctionExpression");
+                break;
+        }
+    }
+    [Fact]
     public void functionExecuteCanParse()
     {
         var inputToken = new List<Token>{

--- a/shisoku.Tests/ParserTest.cs
+++ b/shisoku.Tests/ParserTest.cs
@@ -98,7 +98,7 @@ public class ParserTest
             new TokenSemicolon()
         };
         var expectedAst = new Statement[]{
-            new AstExpression(
+            new StatementExpression(
                 new SubExpression(
                     new NumberExpression(12), new NumberExpression(13)
                 )
@@ -127,7 +127,7 @@ public class ParserTest
         new TokenSemicolon()
     };
         var expectedAst = new Statement[] {
-            new AstConst(
+            new StatementConst(
                 "test",
                 new NumberExpression(12)
             )
@@ -162,10 +162,10 @@ public class ParserTest
         new TokenSemicolon()
     };
         var expectedAst = new Statement[] {
-            new AstConst(
+            new StatementConst(
                 "test",
                 new NumberExpression(12)
-            ), new AstConst(
+            ), new StatementConst(
                 "test2",
                 new NumberExpression(12)
             )
@@ -188,7 +188,7 @@ public class ParserTest
             new TokenCurlyBracketClose()
         };
         var expectedAst = new FunctionExpression(new List<string>(), new Statement[]{
-            new AstConst("test", new NumberExpression(12))
+            new StatementConst("test", new NumberExpression(12))
         });
         (var result, _) = ParseExpression.parse(inputToken.ToArray());
         switch (result)
@@ -236,7 +236,7 @@ public class ParserTest
         expectedArguments.Add("hoge");
         expectedArguments.Add("huga");
         var expectedAst = new FunctionExpression(expectedArguments, new Statement[]{
-                new AstConst("test", new NumberExpression(12))
+                new StatementConst("test", new NumberExpression(12))
             });
         (var result, _) = ParseExpression.parse(inputToken.ToArray());
         switch (result)

--- a/shisoku.Tests/ParserTest.cs
+++ b/shisoku.Tests/ParserTest.cs
@@ -255,35 +255,16 @@ public class ParserTest
     public void CanParseFunctionWithReturn()
     {
         var inputToken = new List<Token>{
-            new TokenCurlyBracketOpen(),
-            new TokenPipe(),
-            new TokenPipe(),
-            new TokenArrow(),
-            new TokenConst(),
-            new TokenIdentifier("test"),
-            new TokenEqual(),
-            new TokenNumber(12),
-            new TokenSemicolon(),
             new TokenReturn(),
             new TokenNumber(12),
-            new TokenCurlyBracketClose()
+            new TokenSemicolon()
         };
-        var expectedAst = new FunctionExpression(new List<string>(), new Statement[]{
-            new StatementConst("test", new NumberExpression(12)),
+        var expectedAst = new Statement[]{
             new StatementReturn(new NumberExpression(12))
-        });
-        (var result, _) = ParseExpression.parse(inputToken.ToArray());
-        switch (result)
-        {
-            case FunctionExpression(var arguments, var body):
-                Assert.Equal(expectedAst.body, body);
-                Assert.Equal(expectedAst.argumentNames, arguments);
-                break;
+        };
 
-            default:
-                Assert.Fail("result is not make FunctionExpression");
-                break;
-        }
+        (var result, _) = ParseStatement.parse(inputToken.ToArray());
+        Assert.Equal(expectedAst, result);
     }
     [Fact]
     public void functionExecuteCanParse()
@@ -307,7 +288,6 @@ public class ParserTest
                 Assert.Fail("result is not make CallExpression");
                 break;
         }
-
     }
 }
 

--- a/shisoku/Ast.cs
+++ b/shisoku/Ast.cs
@@ -15,6 +15,7 @@ public record CallExpression(Expression[] arguments, Expression functionBody) : 
 
 
 public abstract record Statement();
-public record AstExpression(Expression expr) : Statement;
-public record AstConst(string name, Expression expr) : Statement;
+public record StatementExpression(Expression expr) : Statement;
+public record StatementConst(string name, Expression expr) : Statement;
+public record StatementReturn(Expression expr) : Statement;
 

--- a/shisoku/CalcStatement.cs
+++ b/shisoku/CalcStatement.cs
@@ -1,8 +1,8 @@
 namespace shisoku;
-public class CalcStatement
+public class CalcFunctionBody
 {
     //TODO ToIntの命名の変換を行う
-    public static void toInt(Statement[] input, VariableEnvironment env)
+    public static Value Calc(Statement[] input, VariableEnvironment env)
     {
         foreach (Statement statement in input)
         {
@@ -10,15 +10,18 @@ public class CalcStatement
             switch (statement)
             {
                 case StatementExpression(var expr):
-                    Console.WriteLine(CalcExpression.Calc(expr, env));
-                    break;
+                    CalcExpression.Calc(expr, env);
+                    continue;
                 case StatementConst(var name, var expr):
                     env.Add(name, CalcExpression.toInt(CalcExpression.Calc(expr, env)));
-                    break;
+                    continue;
+                case StatementReturn(var expr):
+                    return (CalcExpression.Calc(expr, env));
                 default:
-                    throw new Exception("AST parse Error");
+                    throw new Exception("Statemtnt parse Error");
             }
         }
+        throw new Exception("Return undifinde");
     }
 
 }

--- a/shisoku/CalcStatement.cs
+++ b/shisoku/CalcStatement.cs
@@ -9,10 +9,10 @@ public class CalcStatement
 
             switch (statement)
             {
-                case AstExpression(var expr):
+                case StatementExpression(var expr):
                     Console.WriteLine(CalcExpression.Calc(expr, env));
                     break;
-                case AstConst(var name, var expr):
+                case StatementConst(var name, var expr):
                     env.Add(name, CalcExpression.toInt(CalcExpression.Calc(expr, env)));
                     break;
                 default:

--- a/shisoku/ParseStatement.cs
+++ b/shisoku/ParseStatement.cs
@@ -23,6 +23,7 @@ public class ParseStatement
         var (statement, token) = tokens switch
         {
             [TokenConst, ..] => parseConst(tokens),
+            [TokenReturn, ..] => parseReturn(tokens),
             _ => parseExpressionStatement(tokens)
         };
 
@@ -37,14 +38,23 @@ public class ParseStatement
     private static (Statement, Token[]) parseExpressionStatement(Token[] tokens)
     {
         var (expression, rest) = ParseExpression.parse(tokens);
-        return (new AstExpression(expression), rest);
+        return (new StatementExpression(expression), rest);
     }
     private static (Statement, Token[]) parseConst(Token[] tokens)
     {
-        if (tokens is [TokenConst, TokenIdentifier(var exprName), TokenEqual, .. var rest_token])
+        if (tokens is [TokenConst, TokenIdentifier(var exprName), TokenEqual, .. var restToken])
         {
-            (var expression, var rest) = ParseExpression.parse(rest_token);
-            return (new AstConst(exprName, expression), rest);
+            (var expression, var rest) = ParseExpression.parse(restToken);
+            return (new StatementConst(exprName, expression), rest);
+        }
+        throw new Exception($"Unexpected Tokens: {String.Join<Token>(',', tokens)}");
+    }
+    private static (Statement, Token[]) parseReturn(Token[] tokens)
+    {
+        if (tokens is [TokenReturn, .. var restToken])
+        {
+            (var expression, var rest) = ParseExpression.parse(restToken);
+            return (new StatementReturn(expression), rest);
         }
         throw new Exception($"Unexpected Tokens: {String.Join<Token>(',', tokens)}");
     }

--- a/shisoku/Program.cs
+++ b/shisoku/Program.cs
@@ -23,7 +23,7 @@ class Program
         {
             if (input != null)
             {
-                Calculate(input, isVerbose, new VariableEnvironment());
+                Console.WriteLine(Calculate(input, isVerbose, new VariableEnvironment()));
             }
             else
             {
@@ -46,7 +46,7 @@ class Program
                     Console.Write("> ");
                     input = Console.ReadLine();
                 } while (input is null || input.Length == 0);
-                Calculate(input, isVerboseOption, env);
+                Console.WriteLine(Calculate(input, isVerboseOption, env));
             }
             catch (Exception e)
             {
@@ -55,11 +55,14 @@ class Program
         }
 
     }
-    static void Calculate(string input, bool isVerboseOption, VariableEnvironment env)
+    static Value Calculate(string input, bool isVerboseOption, VariableEnvironment env)
     {
         var tokens = Lexer.lex(input);
-
-        var (tree, _) = ParseStatement.parse(tokens.ToArray());
+        if (tokens[0] is not TokenConst)
+        {
+            tokens.Insert(0, new TokenReturn());
+        }
+        var (statements, _) = ParseStatement.parse(tokens.ToArray());
         //TODO 諸々仕様固まってから考える
         if (isVerboseOption)
         {
@@ -67,9 +70,13 @@ class Program
             //Console.WriteLine(PrettyPrinter.PrettyPrint(tree));
             //TODO PrettyPrintのStatement対応
             Console.WriteLine("データ構造");
-            Console.WriteLine(tree);
+            Console.WriteLine(statements);
         }
-        CalcStatement.toInt(tree, env);
+        if (statements.Length > 1)
+        {
+            throw new Exception("複数文は受け付けられません");
+        }
+        return CalcFunctionBody.Calc(statements, env);
     }
 }
 // -eの時のみ省略して行う


### PR DESCRIPTION
追加点：
StatementReturn　の定義とパーサーの実装。

変更点：
以下のrecord名の変更
AstConst　→ StatementConst
AstExpression　→ StatementExpression

--exp,replでは一回に１文までしか受け付けない仕様に変更