### PR TITLE
CallFunctionCalcの作成/VariableEnviromentを独自クラスに変更

### DIFF
--- a/shisoku.Integration/functionCanHaveConstStatement.shisoku
+++ b/shisoku.Integration/functionCanHaveConstStatement.shisoku
@@ -1,0 +1,6 @@
+const f = {|a, b |->
+const c=3;
+return a+b*2+c*3;
+};
+
+return f(a=1,b=2);

--- a/shisoku.Integration/functionCanReturnFunction.shisoku
+++ b/shisoku.Integration/functionCanReturnFunction.shisoku
@@ -1,0 +1,5 @@
+const f= {|a |->
+return{|b|-> return a+b;};
+};
+return f(a=5)(b=7);
+

--- a/shisoku.Integration/integration_calc.sh
+++ b/shisoku.Integration/integration_calc.sh
@@ -40,11 +40,11 @@ function main() {
     sum_exit_code=$((sum_exit_code + $?))
     run_test_file_case "複数分の入ったファイルを読み込んで実行できる" "shisoku.Integration/test.shisoku" "2" 
     sum_exit_code=$((sum_exit_code + $?))
-    run_test_file_case "名前なし関数の実行ができる" "shisoku.Integration/namelessFunctionTest.shisoku" "2" 
+    run_test_file_case "名前なし関数の実行ができる" "shisoku.Integration/namelessFunctionTest.shisoku" "8" 
     sum_exit_code=$((sum_exit_code + $?))
-    run_test_file_case "関数内で関数を定義できる" "shisoku.Integration/functionCunRerunFunction.shisoku" "2" 
+    run_test_file_case "関数内で関数を定義できる" "shisoku.Integration/functionCanReturnFunction.shisoku" "12" 
     sum_exit_code=$((sum_exit_code + $?))
-    run_test_file_case "関数ないで変数を定義できる" "shisoku.Integration/functionCanHaveConst.shisoku" "2" 
+    run_test_file_case "関数ないで変数を定義できる" "shisoku.Integration/functionCanHaveConstStatement.shisoku" "14" 
     sum_exit_code=$((sum_exit_code + $?))
 
     if [ ${sum_exit_code} == "0" ]; then

--- a/shisoku.Integration/integration_calc.sh
+++ b/shisoku.Integration/integration_calc.sh
@@ -40,6 +40,12 @@ function main() {
     sum_exit_code=$((sum_exit_code + $?))
     run_test_file_case "複数分の入ったファイルを読み込んで実行できる" "shisoku.Integration/test.shisoku" "2" 
     sum_exit_code=$((sum_exit_code + $?))
+    run_test_file_case "名前なし関数の実行ができる" "shisoku.Integration/namelessFunctionTest.shisoku" "2" 
+    sum_exit_code=$((sum_exit_code + $?))
+    run_test_file_case "関数内で関数を定義できる" "shisoku.Integration/functionCunRerunFunction.shisoku" "2" 
+    sum_exit_code=$((sum_exit_code + $?))
+    run_test_file_case "関数ないで変数を定義できる" "shisoku.Integration/functionCanHaveConst.shisoku" "2" 
+    sum_exit_code=$((sum_exit_code + $?))
 
     if [ ${sum_exit_code} == "0" ]; then
         return 0

--- a/shisoku.Integration/namelessFunctionTest.shisoku
+++ b/shisoku.Integration/namelessFunctionTest.shisoku
@@ -1,6 +1,4 @@
-const d=4;
 return {|a,b|->
 const c=3;
-return a+b*2+c*3+d*4;
-}(b=2,a=1);
+return a+b*2+c;}(a=1,b=2);
 

--- a/shisoku.Integration/namelessFunctionTest.shisoku
+++ b/shisoku.Integration/namelessFunctionTest.shisoku
@@ -1,0 +1,6 @@
+const d=4;
+return {|a,b|->
+const c=3;
+return a+b*2+c*3+d*4;
+}(b=2,a=1);
+

--- a/shisoku.Tests/CalcTest.cs
+++ b/shisoku.Tests/CalcTest.cs
@@ -1,6 +1,5 @@
 namespace shisoku.Tests;
 using Xunit;
-using VariableEnvironment = System.Collections.Generic.Dictionary<string, int>;
 using shisoku;
 
 public class CalcTest
@@ -131,7 +130,7 @@ public class CalcTest
             new Expression[] { },
                 new FunctionExpression(new List<string>(),
                 new Statement[] {
-                    new AstExpression(new AddExpression(
+                    new StatementReturn(new AddExpression(
                         new NumberExpression(1),new NumberExpression(2)
                         ))
             }

--- a/shisoku.Tests/CalcTest.cs
+++ b/shisoku.Tests/CalcTest.cs
@@ -109,11 +109,11 @@ public class CalcTest
     [Fact]
     public void functionExpressionCanEvaluate()
     {
-        var expectedValue = new FunctionValue(new List<string>(), new Statement[] { });
+        var expectedValue = new FunctionValue(new List<string>(), new Statement[] { }, new VariableEnvironment());
         var result = shisoku.CalcExpression.Calc(new FunctionExpression(new List<string>(), new Statement[] { }), new VariableEnvironment());
         switch (result)
         {
-            case FunctionValue(var arguments, var body):
+            case FunctionValue(var arguments, var body, var env):
                 Assert.Equal(expectedValue.argumentNames, arguments);
                 Assert.Equal(expectedValue.body, body);
                 break;

--- a/shisoku.Tests/CalcTest.cs
+++ b/shisoku.Tests/CalcTest.cs
@@ -124,4 +124,22 @@ public class CalcTest
                 break;
         }
     }
+    [Fact]
+    public void FunctionCallCanEvaluate()
+    {
+        var expression = new CallExpression(
+            new Expression[] { },
+                new FunctionExpression(new List<string>(),
+                new Statement[] {
+                    new AstExpression(new AddExpression(
+                        new NumberExpression(1),new NumberExpression(2)
+                        ))
+            }
+            )
+        );
+        var expectedValue = new IntValue(3);
+        var result = shisoku.CalcExpression.Calc(expression, new VariableEnvironment());
+        Assert.Equal(expectedValue, result);
+
+    }
 }

--- a/shisoku.Tests/CalcTest.cs
+++ b/shisoku.Tests/CalcTest.cs
@@ -140,6 +140,5 @@ public class CalcTest
         var expectedValue = new IntValue(3);
         var result = shisoku.CalcExpression.Calc(expression, new VariableEnvironment());
         Assert.Equal(expectedValue, result);
-
     }
 }

--- a/shisoku.Tests/CalcTest.cs
+++ b/shisoku.Tests/CalcTest.cs
@@ -140,4 +140,95 @@ public class CalcTest
         var result = shisoku.CalcExpression.Calc(expression, new VariableEnvironment());
         Assert.Equal(expectedValue, result);
     }
+    [Fact]
+    public void functionCanHaveConst()
+    {
+        var expectedValue = new FunctionValue(
+            new List<string>(),
+            new Statement[] {
+                new StatementConst("x",new NumberExpression(12)),
+                new StatementReturn(new VariableExpression("x"))
+            },
+            new VariableEnvironment()
+        );
+        var result = shisoku.CalcExpression.Calc(new FunctionExpression(
+            new List<string>(),
+            new Statement[] {
+                new StatementConst("x",new NumberExpression(12)),
+                new StatementReturn(new VariableExpression("x"))
+            }),
+            new VariableEnvironment()
+        );
+        switch (result)
+        {
+            case FunctionValue(var arguments, var body, var env):
+                Assert.Equal(expectedValue.argumentNames, arguments);
+                Assert.Equal(expectedValue.body, body);
+                break;
+
+            default:
+                Assert.Fail("result is not make CallExpression");
+                break;
+        }
+    }
+    [Fact]
+    public void CallFunctionCanCalc()
+    {
+        var expectedValue = new IntValue(12);
+        var result = shisoku.CalcExpression.Calc(
+        new CallExpression(
+                new (string, Expression)[] { ("x", new NumberExpression(12)) },
+                new FunctionExpression(
+                    new List<string>() { "x" },
+                    new Statement[] {
+                            new StatementReturn(new VariableExpression("x"))
+                    }
+                )
+            ),
+            new VariableEnvironment()
+        );
+        Assert.Equal(expectedValue, result);
+    }
+    [Fact]
+    public void CallFunctionCannotCalcWithExcessiveArguments()
+    {
+        var expectedValue = new IntValue(12);
+        Assert.Throws<Exception>(() =>
+            shisoku.CalcExpression.Calc(
+            new CallExpression(
+                    new (string, Expression)[] { ("x", new NumberExpression(12)), ("y", new NumberExpression(13)) },
+                    new FunctionExpression(
+                        new List<string>() { "x" },
+                        new Statement[] {
+                                new StatementReturn(new VariableExpression("x"))
+                        }
+                    )
+                ),
+                new VariableEnvironment()
+            )
+        );
+    }
+    [Fact]
+    public void CallFunctionCannotCalcWithInsufficientArguments()
+    {
+        var expectedValue = new IntValue(12);
+        Assert.Throws<Exception>(() =>
+            shisoku.CalcExpression.Calc(
+            new CallExpression(
+                    new (string, Expression)[] { ("x", new NumberExpression(12)) },
+                    new FunctionExpression(
+                        new List<string>() { "x", "y" },
+                        new Statement[] {
+                                new StatementReturn(new AddExpression(
+                                    new VariableExpression("x"),
+                                    new VariableExpression("y")
+                                )
+                            )
+                        }
+                    )
+                ),
+                new VariableEnvironment()
+            )
+        );
+    }
 }

--- a/shisoku.Tests/CalcTest.cs
+++ b/shisoku.Tests/CalcTest.cs
@@ -127,7 +127,7 @@ public class CalcTest
     public void FunctionCallCanEvaluate()
     {
         var expression = new CallExpression(
-            new Expression[] { },
+            new (string, Expression)[] { },
                 new FunctionExpression(new List<string>(),
                 new Statement[] {
                     new StatementReturn(new AddExpression(

--- a/shisoku/CalcExpression.cs
+++ b/shisoku/CalcExpression.cs
@@ -74,11 +74,6 @@ public class CalcExpression
                 {
                     return new FunctionValue(argumentNames, body);
                 }
-            case CallExpression(var argumentExpressions, var functionExpression):
-                {
-                    var argumentValues = argumentExpressions.Select(x => Calc(x, env)).ToList();
-                    return toFunc(Calc(functionExpression, env));
-                }
             default:
                 throw new Exception($"Evaluation Error:{input}");
         }

--- a/shisoku/CalcExpression.cs
+++ b/shisoku/CalcExpression.cs
@@ -74,28 +74,21 @@ public class CalcExpression
                 {
                     return new FunctionValue(argumentNames, body, env);
                 }
-            case CallExpression(var arguments, var function):
+            case CallExpression(var argumentsExpressions, var function):
                 {
                     var targetValue = Calc(function, env);
-                    switch (targetValue)
+                    var givenArgumentNames = argumentsExpressions.Select(x => x.Item1).ToList();
+                    var givenArgumentNameSet = new HashSet<string>(givenArgumentNames);
+                    var (argumentNames, body, funcEnv) = toFunc(targetValue);
+                    var expectedArgumentNames = new HashSet<string>(argumentNames);
+                    if (!expectedArgumentNames.SetEquals(givenArgumentNames))
                     {
-                        case FunctionValue(var argumentNames, var body, var funcEnv):
-                            var newEnv = funcEnv.WithNewContext();
-                            for (int i = 0; i < arguments.Length; i++)
-                            {
-                                if (argumentNames.Contains(arguments[i].Item1))
-                                {
-                                    newEnv.Add(arguments[i].Item1, Calc(arguments[i].Item2, newEnv));
-                                }
-                                else
-                                {
-                                    throw new Exception($"{arguments[i].Item1} is not defined. in {argumentNames}");
-                                }
-                            }
-                            return CalcFunctionBody.Calc(body, newEnv);
-                        default:
-                            throw new Exception($"Method not implemented.");
+                        throw new Exception($"Method not implemented.");
                     }
+                    var givenArgumentsValues = argumentsExpressions.Select(
+                    argument => (argument.Item1, Calc(argument.Item2, env))).ToList();
+                    var newEnv = funcEnv.WithNewContext(givenArgumentsValues.ToArray());
+                    return CalcFunctionBody.Calc(body, newEnv);
                 }
             default:
                 throw new Exception($"Evaluation Error:{input}");

--- a/shisoku/CalcExpression.cs
+++ b/shisoku/CalcExpression.cs
@@ -76,6 +76,7 @@ public class CalcExpression
                 }
             case CallExpression(var argumentExpressions, var functionExpression):
                 {
+                    var argumentValues = argumentExpressions.Select(x => Calc(x, env)).ToList();
                     return toFunc(Calc(functionExpression, env));
                 }
             default:

--- a/shisoku/CalcExpression.cs
+++ b/shisoku/CalcExpression.cs
@@ -16,8 +16,8 @@ public class CalcExpression
     {
         switch (input)
         {
-            case FunctionValue(var argumentNames, var body):
-                return new FunctionValue(argumentNames, body);
+            case FunctionValue(var argumentNames, var body, var env):
+                return new FunctionValue(argumentNames, body, env);
             default:
                 throw new Exception($"Evaluation Error:augment type is not FunctionValue({input})");
         }
@@ -72,15 +72,15 @@ public class CalcExpression
                 }
             case FunctionExpression(var argumentNames, var body):
                 {
-                    return new FunctionValue(argumentNames, body);
+                    return new FunctionValue(argumentNames, body, env);
                 }
             case CallExpression(var arguments, var function):
                 {
-                    var newEnv = env.WithNewContext();
-                    var targetValue = Calc(function, newEnv);
+                    var targetValue = Calc(function, env);
                     switch (targetValue)
                     {
-                        case FunctionValue(var argumentNames, var body):
+                        case FunctionValue(var argumentNames, var body, var funcEnv):
+                            var newEnv = funcEnv.WithNewContext();
                             for (int i = 0; i < arguments.Length; i++)
                             {
                                 if (argumentNames.Contains(arguments[i].Item1))

--- a/shisoku/CalcExpression.cs
+++ b/shisoku/CalcExpression.cs
@@ -74,6 +74,29 @@ public class CalcExpression
                 {
                     return new FunctionValue(argumentNames, body);
                 }
+            case CallExpression(var arguments, var function):
+                {
+                    var newEnv = env.WithNewContext();
+                    var targetValue = Calc(function, newEnv);
+                    switch (targetValue)
+                    {
+                        case FunctionValue(var argumentNames, var body):
+                            for (int i = 0; i < arguments.Length; i++)
+                            {
+                                if (argumentNames.Contains(arguments[i].Item1))
+                                {
+                                    newEnv.Add(arguments[i].Item1, Calc(arguments[i].Item2, newEnv));
+                                }
+                                else
+                                {
+                                    throw new Exception($"{arguments[i].Item1} is not defined. in {argumentNames}");
+                                }
+                            }
+                            return CalcFunctionBody.Calc(body, newEnv);
+                        default:
+                            throw new Exception($"Method not implemented.");
+                    }
+                }
             default:
                 throw new Exception($"Evaluation Error:{input}");
         }

--- a/shisoku/CalcExpression.cs
+++ b/shisoku/CalcExpression.cs
@@ -12,6 +12,16 @@ public class CalcExpression
                 throw new Exception($"Evaluation Error:augment type is not int({input})");
         }
     }
+    public static FunctionValue toFunc(Value input)
+    {
+        switch (input)
+        {
+            case FunctionValue(var argumentNames, var body):
+                return new FunctionValue(argumentNames, body);
+            default:
+                throw new Exception($"Evaluation Error:augment type is not FunctionValue({input})");
+        }
+    }
 
     public static Value Calc(Expression input, VariableEnvironment env)
     {
@@ -24,7 +34,7 @@ public class CalcExpression
                 }
             case VariableExpression(var name):
                 {
-                    return new IntValue(env[name]);
+                    return env[name];
                 }
             case BoolExpression(var value):
                 {
@@ -63,6 +73,10 @@ public class CalcExpression
             case FunctionExpression(var argumentNames, var body):
                 {
                     return new FunctionValue(argumentNames, body);
+                }
+            case CallExpression(var argumentExpressions, var functionExpression):
+                {
+                    return toFunc(Calc(functionExpression, env));
                 }
             default:
                 throw new Exception($"Evaluation Error:{input}");

--- a/shisoku/CalcStatement.cs
+++ b/shisoku/CalcStatement.cs
@@ -13,7 +13,6 @@ public class CalcFunctionBody
                     CalcExpression.Calc(expr, env);
                     continue;
                 case StatementConst(var name, var expr):
-                    //Envのリストに対して思った通りの挿入をする関数を作る必要がある。
                     env.Add(name, CalcExpression.Calc(expr, env));
                     continue;
                 case StatementReturn(var expr):

--- a/shisoku/CalcStatement.cs
+++ b/shisoku/CalcStatement.cs
@@ -13,7 +13,8 @@ public class CalcFunctionBody
                     CalcExpression.Calc(expr, env);
                     continue;
                 case StatementConst(var name, var expr):
-                    env.Add(name, CalcExpression.toInt(CalcExpression.Calc(expr, env)));
+                    //Envのリストに対して思った通りの挿入をする関数を作る必要がある。
+                    env.Add(name, CalcExpression.Calc(expr, env));
                     continue;
                 case StatementReturn(var expr):
                     return (CalcExpression.Calc(expr, env));

--- a/shisoku/ParseExpression.cs
+++ b/shisoku/ParseExpression.cs
@@ -126,21 +126,14 @@ public class ParseExpression
                     throw new Exception($"Unexpected Tokens: {String.Join<Token>(',', input)}");
                 }
             case [TokenCurlyBracketOpen, TokenPipe, .. var target]:
-                (var argumentName, var bodyTokens) = argumentPaser(target);
-                var bodyRest = new Token[] { };
-                var bodys = new Statement[] { };
-                while (true)
+                (var argumentNames, var bodyTokens) = argumentsPaser(target);
+                var bodys = new List<Statement> { };
+                while (bodyTokens is not [TokenCurlyBracketClose, ..])
                 {
-                    (var body, var otherTokens) = ParseStatement.parseStatement(bodyTokens);
-                    bodyRest = otherTokens;
-                    bodys = bodys.Append(body).ToArray();
-
-                    if (bodyRest[0] is TokenCurlyBracketClose)
-                    {
-                        return (new FunctionExpression(argumentName, bodys), otherTokens[1..]);
-                    }
+                    (var body, bodyTokens) = ParseStatement.parseStatement(bodyTokens);
+                    bodys.Add(body);
                 }
-                throw new Exception($"Unexpected Tokens: {String.Join<Token>(',', input)}");
+                return (new FunctionExpression(argumentNames, bodys.ToArray()), bodyTokens[1..]);
             case [TokenTrue, .. var rest]:
                 return (new BoolExpression(true), rest);
             case [TokenFalse, .. var rest]:
@@ -154,7 +147,7 @@ public class ParseExpression
 
     }
 
-    static (List<string>, shisoku.Token[]) argumentPaser(shisoku.Token[] input)
+    static (List<string>, shisoku.Token[]) argumentsPaser(shisoku.Token[] input)
     {
         var target = input;
         var result = new List<string>();

--- a/shisoku/ParseExpression.cs
+++ b/shisoku/ParseExpression.cs
@@ -14,7 +14,6 @@ public class ParseExpression
         {
             (var arguments, rest) = parseArguments(innerRest);
             result = new CallExpression(arguments, result);
-            break;
         }
         return (result, rest);
     }

--- a/shisoku/Program.cs
+++ b/shisoku/Program.cs
@@ -1,5 +1,4 @@
 ﻿// See https://aka.ms/new-console-template for more information
-global using VariableEnvironment = System.Collections.Generic.Dictionary<string, int>;
 namespace shisoku;
 using System.CommandLine;
 using System.IO;

--- a/shisoku/Value.cs
+++ b/shisoku/Value.cs
@@ -1,4 +1,5 @@
 namespace shisoku;
+using System.Linq;
 public abstract record Value();
 public record IntValue(int Value) : Value
 {
@@ -12,3 +13,43 @@ public record FunctionValue(List<string> argumentNames, Statement[] body) : Valu
 {
     public override string ToString() => $"FunctionValue({string.Join(", ", argumentNames)})";
 };
+
+
+public class VariableEnvironment
+{
+    List<System.Collections.Generic.Dictionary<string, Value>> envDictionaries;
+    public VariableEnvironment(List<Dictionary<string, Value>> envDictionaries)
+    {
+        this.envDictionaries = envDictionaries;
+    }
+    public VariableEnvironment()
+    {
+        this.envDictionaries = new List<Dictionary<string, Value>> { new Dictionary<string, Value>() };
+    }
+    public void Add(string name, Value value)
+    {
+        envDictionaries.Last().Add(name, value);
+    }
+    public VariableEnvironment WithNewContext()
+    {
+        var newEnvDictionaries = new List<Dictionary<string, Value>>(envDictionaries);
+        newEnvDictionaries.Add(new Dictionary<string, Value>());
+        return new VariableEnvironment(newEnvDictionaries);
+    }
+    public Value this[string name]
+    {
+        get
+        {
+            for (var counter = 0; counter <= envDictionaries.Count; counter++)
+            {
+                var env = envDictionaries[envDictionaries.Count - counter];
+                if (env.ContainsKey(name))
+                {
+                    return env[name];
+                }
+            }
+            throw new Exception($"Evaluation Error:variable {name} is not defined");
+        }
+    }
+}
+

--- a/shisoku/Value.cs
+++ b/shisoku/Value.cs
@@ -9,7 +9,7 @@ public record BoolValue(bool Value) : Value
 {
     public override string ToString() => Value.ToString();
 };
-public record FunctionValue(List<string> argumentNames, Statement[] body) : Value
+public record FunctionValue(List<string> argumentNames, Statement[] body, VariableEnvironment env) : Value
 {
     public override string ToString() => $"FunctionValue({string.Join(", ", argumentNames)})";
 };

--- a/shisoku/Value.cs
+++ b/shisoku/Value.cs
@@ -36,6 +36,12 @@ public class VariableEnvironment
         newEnvDictionaries.Add(new Dictionary<string, Value>());
         return new VariableEnvironment(newEnvDictionaries);
     }
+    public VariableEnvironment WithNewContext((string, Value)[] givenEnvDictionaries)
+    {
+        var newEnvDictionaries = new List<Dictionary<string, Value>>(envDictionaries);
+        newEnvDictionaries.Add(givenEnvDictionaries.ToDictionary(x => x.Item1, x => x.Item2));
+        return new VariableEnvironment(newEnvDictionaries);
+    }
     public Value this[string name]
     {
         get

--- a/shisoku/Value.cs
+++ b/shisoku/Value.cs
@@ -40,9 +40,9 @@ public class VariableEnvironment
     {
         get
         {
-            for (var counter = 0; counter <= envDictionaries.Count; counter++)
+            for (var counter = envDictionaries.Count - 1; counter >= 0; counter--)
             {
-                var env = envDictionaries[envDictionaries.Count - counter];
+                var env = envDictionaries[counter];
                 if (env.ContainsKey(name))
                 {
                     return env[name];


### PR DESCRIPTION
## 追加機能
CallFunctionCalcを追加し、関数実行が可能になった。
## 変更機能
VariableEnviromentの方を`Dictionary<string,Value>`から`List<Dictionary<string,Value>>`に変更し、`Add()`・`WithNewContext()`・`this[string].get()` を追加した。

todo
- [x] 単体テストケースの作成
- [x] 結合テストケースの作成