### PR TITLE
CallExpressionの作成

### DIFF
--- a/shisoku.Tests/ParserTest.cs
+++ b/shisoku.Tests/ParserTest.cs
@@ -289,5 +289,64 @@ public class ParserTest
                 break;
         }
     }
+    [Fact]
+    public void functionExecuteInArgmentCanParse()
+    {
+
+        var inputToken = new List<Token>{
+                new TokenIdentifier("hoge"),
+                new TokenBracketOpen(),
+                new TokenIdentifier("huga"),
+                new TokenEqual(),
+                new TokenNumber(12),
+                new TokenBracketClose()
+            };
+        var expectedAst = new CallExpression(new (string, Expression)[] { ("huga", new NumberExpression(12)) }, new VariableExpression("hoge"));
+        (var result, _) = ParseExpression.parse(inputToken.ToArray());
+        Console.WriteLine(result);
+        switch (result)
+        {
+            case CallExpression(var arguments, var body):
+                Assert.Equal(expectedAst.arguments, arguments);
+                Assert.Equal(expectedAst.functionBody, body);
+                break;
+
+            default:
+                Assert.Fail("result is not make CallExpression");
+                break;
+        }
+
+    }
+    [Fact]
+    public void functionExecuteInArgmentsCanParse()
+    {
+
+        var inputToken = new List<Token>{
+                new TokenIdentifier("hoge"),
+                new TokenBracketOpen(),
+                new TokenIdentifier("huga"),
+                new TokenEqual(),
+                new TokenNumber(12),
+                new TokenComma(),
+                new TokenIdentifier("piyo"),
+                new TokenEqual(),
+                new TokenNumber(13),
+                new TokenBracketClose()
+            };
+        var expectedAst = new CallExpression(new (string, Expression)[] { ("huga", new NumberExpression(12)), ("piyo", new NumberExpression(13)) }, new VariableExpression("hoge"));
+        (var result, _) = ParseExpression.parse(inputToken.ToArray());
+        Console.WriteLine(result);
+        switch (result)
+        {
+            case CallExpression(var arguments, var body):
+                Assert.Equal(expectedAst.arguments, arguments);
+                Assert.Equal(expectedAst.functionBody, body);
+                break;
+
+            default:
+                Assert.Fail("result is not make CallExpression");
+                break;
+        }
+    }
 }
 

--- a/shisoku.Tests/ParserTest.cs
+++ b/shisoku.Tests/ParserTest.cs
@@ -274,7 +274,7 @@ public class ParserTest
                 new TokenBracketOpen(),
                 new TokenBracketClose()
             };
-        var expectedAst = new CallExpression(new Expression[] { }, new VariableExpression("hoge"));
+        var expectedAst = new CallExpression(new (string, Expression)[] { }, new VariableExpression("hoge"));
         (var result, _) = ParseExpression.parse(inputToken.ToArray());
         Console.WriteLine(result);
         switch (result)

--- a/shisoku.Tests/ParserTest.cs
+++ b/shisoku.Tests/ParserTest.cs
@@ -267,7 +267,7 @@ public class ParserTest
         Assert.Equal(expectedAst, result);
     }
     [Fact]
-    public void functionExecuteCanParse()
+    public void CallExpressionWithoutArgumentsCanParse()
     {
         var inputToken = new List<Token>{
                 new TokenIdentifier("hoge"),
@@ -285,12 +285,12 @@ public class ParserTest
                 break;
 
             default:
-                Assert.Fail("result is not make CallExpression");
+                Assert.Fail("Tokens Can not parse CallExpression");
                 break;
         }
     }
     [Fact]
-    public void functionExecuteInArgmentCanParse()
+    public void CallExpressionWithArgumentCanParse()
     {
 
         var inputToken = new List<Token>{
@@ -312,13 +312,13 @@ public class ParserTest
                 break;
 
             default:
-                Assert.Fail("result is not make CallExpression");
+                Assert.Fail("Tokens Can not parse CallExpression");
                 break;
         }
 
     }
     [Fact]
-    public void functionExecuteInArgmentsCanParse()
+    public void CallExpressionWithArgumentsCanParse()
     {
 
         var inputToken = new List<Token>{
@@ -344,9 +344,26 @@ public class ParserTest
                 break;
 
             default:
-                Assert.Fail("result is not make CallExpression");
+                Assert.Fail("Tokens Cannot parse CallExpression");
                 break;
         }
+    }
+    [Fact]
+    public void CallExpressionWithArgumentsWithoutCommaCannotParse()
+    {
+
+        var inputToken = new List<Token>{
+                new TokenIdentifier("hoge"),
+                new TokenBracketOpen(),
+                new TokenIdentifier("huga"),
+                new TokenEqual(),
+                new TokenNumber(12),
+                new TokenIdentifier("piyo"),
+                new TokenEqual(),
+                new TokenNumber(13),
+                new TokenBracketClose()
+            };
+        Assert.Throws<Exception>(() => ParseExpression.parse(inputToken.ToArray()));
     }
 }
 

--- a/shisoku/Ast.cs
+++ b/shisoku/Ast.cs
@@ -10,7 +10,7 @@ public record MulExpression(Expression left, Expression right) : Expression;
 public record DivExpression(Expression left, Expression right) : Expression;
 public record EqualExpression(Expression left, Expression right) : Expression;
 public record FunctionExpression(List<String> argumentNames, Statement[] body) : Expression;
-public record CallExpression(Expression[] arguments, Expression functionBody) : Expression;
+public record CallExpression((string, Expression)[] arguments, Expression functionBody) : Expression;
 // TODO 型の実装が終わったらFunctionの定義もそれに合わせて変更する。
 
 

--- a/shisoku/ParseExpression.cs
+++ b/shisoku/ParseExpression.cs
@@ -30,11 +30,17 @@ public class ParseExpression
                 case [TokenIdentifier(var argumentName), TokenEqual, .. var target2]:
                     var (argumentExpression, rest2) = parse(target2);
                     arguments = arguments.Append((argumentName, argumentExpression)).ToArray();
-                    target = rest2;
-                    continue;
-                case [TokenComma, .. var target2]:
-                    target = target2;
-                    continue;
+                    switch (rest2)
+                    {
+                        case [TokenBracketClose, .. var rest3]:
+                            {
+                                return (arguments, rest3);
+                            }
+                        case [TokenComma, .. var rest3]:
+                            target = rest3;
+                            continue;
+                    }
+                    throw new Exception($"Cannot parse arguments in: {String.Join<Token>(',', target)}");
                 case [TokenBracketClose, .. var target2]:
                     return (arguments, target2);
                 default:

--- a/shisoku/ParseExpression.cs
+++ b/shisoku/ParseExpression.cs
@@ -11,7 +11,7 @@ public class ParseExpression
         (var result, var rest) = parseComparator(input);
         while (rest is [TokenBracketOpen, .. var innerRest])
         {
-            var arguments = new Expression[] { };
+            var arguments = new (string, Expression)[] { };
             while (innerRest[0] is not TokenBracketClose)
             {
                 (var argument, var otherTokens) = parse(innerRest);
@@ -26,7 +26,7 @@ public class ParseExpression
                     default:
                         throw new Exception("関数の引数の区切りが不正です。");
                 }
-                arguments = arguments.Append(argument).ToArray();
+                arguments = arguments.Append(("hoge", argument)).ToArray();
             }
             result = new CallExpression(arguments, result);
             rest = innerRest;


### PR DESCRIPTION
# TODO
- [x] Function(Hoge=fuga)をパースできるようにする
   - [x] `[IdentifireToken ,EqualToken, .. rest]`のときに`(identifireToken.name,Expression)[]`をargumentsとして返せるようにする
  