### PR TITLE
integration テストを高速化する

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -20,8 +20,6 @@ tasks:
     cmds:
       - dotnet test
   integration-test:
-    deps:
-      - build
     desc: "Runs integration tests"
     cmds:
       - shisoku.Integration/integration_calc.sh

--- a/shisoku.Integration/integration_calc.sh
+++ b/shisoku.Integration/integration_calc.sh
@@ -4,7 +4,7 @@ BINARY_DIR="bin"
 BINARY="${BINARY_DIR}/shisoku"
 
 function main() {
-    dotnet publish shisoku --output ${BINARY_DIR}
+    dotnet publish shisoku --configuration Release --output ${BINARY_DIR}
 
     local sum_exit_code=0
     run_test_exp_case "足し算" "1+1;" 2

--- a/shisoku.Integration/integration_calc.sh
+++ b/shisoku.Integration/integration_calc.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
+
+BINARY_DIR="bin"
+BINARY="${BINARY_DIR}/shisoku"
+
 function main() {
+    dotnet publish shisoku --output ${BINARY_DIR}
+
     local sum_exit_code=0
     run_test_exp_case "足し算" "1+1;" 2
     sum_exit_code=$((sum_exit_code + $?))
@@ -32,23 +38,23 @@ function main() {
     sum_exit_code=$((sum_exit_code + $?))
     run_test_exp_case "Booleanが扱える" "1==1;" True
     sum_exit_code=$((sum_exit_code + $?))
-    run_test_exp_case "Booleanが扱える(False)" "2==1;" False 
+    run_test_exp_case "Booleanが扱える(False)" "2==1;" False
     sum_exit_code=$((sum_exit_code + $?))
-    run_test_exp_case "Booleanが扱える(bool同士)" "true==true;" True 
+    run_test_exp_case "Booleanが扱える(bool同士)" "true==true;" True
     sum_exit_code=$((sum_exit_code + $?))
-    run_test_exp_case "Booleanが混ざった複合演算ができる" "true== (1+1 == 2);" True 
+    run_test_exp_case "Booleanが混ざった複合演算ができる" "true== (1+1 == 2);" True
     sum_exit_code=$((sum_exit_code + $?))
-    run_test_file_case "複数分の入ったファイルを読み込んで実行できる" "shisoku.Integration/test.shisoku" "2" 
+    run_test_file_case "複数分の入ったファイルを読み込んで実行できる" "shisoku.Integration/test.shisoku" "2"
     sum_exit_code=$((sum_exit_code + $?))
-    run_test_file_case "名前なし関数の実行ができる" "shisoku.Integration/namelessFunctionTest.shisoku" "8" 
+    run_test_file_case "名前なし関数の実行ができる" "shisoku.Integration/namelessFunctionTest.shisoku" "8"
     sum_exit_code=$((sum_exit_code + $?))
-    run_test_file_case "関数内で関数を定義できる" "shisoku.Integration/functionCanReturnFunction.shisoku" "12" 
+    run_test_file_case "関数内で関数を定義できる" "shisoku.Integration/functionCanReturnFunction.shisoku" "12"
     sum_exit_code=$((sum_exit_code + $?))
-    run_test_file_case "関数ないで変数を定義できる" "shisoku.Integration/functionCanHaveConstStatement.shisoku" "14" 
+    run_test_file_case "関数ないで変数を定義できる" "shisoku.Integration/functionCanHaveConstStatement.shisoku" "14"
     sum_exit_code=$((sum_exit_code + $?))
-    run_test_file_case "再帰関数を定義できる" "shisoku.Integration/RecursionFunction.shisoku" "5050" 
+    run_test_file_case "再帰関数を定義できる" "shisoku.Integration/RecursionFunction.shisoku" "5050"
     sum_exit_code=$((sum_exit_code + $?))
-    run_test_file_case "ユークリッドの互除法" "shisoku.Integration/EuclideanAlgorithm.shisoku" "61" 
+    run_test_file_case "ユークリッドの互除法" "shisoku.Integration/EuclideanAlgorithm.shisoku" "61"
     sum_exit_code=$((sum_exit_code + $?))
 
     if [ ${sum_exit_code} == "0" ]; then
@@ -64,7 +70,7 @@ function run_test_exp_case() {
     local expected="$3"
 
     local output
-    output=$(dotnet run --no-build --project shisoku -- --exp "${input}" 2>/dev/null)
+    output=$($BINARY --exp "${input}" 2>/dev/null)
     local error_code=$?
     if [ "${output}" = "${expected}" ]; then
         echo "${case_name}:Pass"
@@ -83,7 +89,7 @@ function run_test_file_case() {
     local expected="$3"
 
     local output
-    output=$(dotnet run --no-build --project shisoku -- --file "${input}" 2>/dev/null)
+    output=$($BINARY --file "${input}" 2>/dev/null)
     local error_code=$?
     if [ "${output}" = "${expected}" ]; then
         echo "${case_name}:Pass"


### PR DESCRIPTION
fix #70 

毎回コンパイルしていたところを、１度コンパイルしたものを使いまわす形式に変更。
既存で１５秒かかるところ、３秒程度になりました。

```
$ time task integration-test
MSBuild version 17.7.3+8ec440e68 for .NET
  Determining projects to restore...
  All projects are up-to-date for restore.
  shisoku -> /workspaces/csharp-shisoku/shisoku/bin/Release/net7.0/shisoku.dll
  shisoku -> /workspaces/csharp-shisoku/bin/
足し算:Pass
掛け算:Pass
（）付きの計算式:Pass
割算が優先:Pass
（）の後に（）が来ている:Pass
空白は全て無視するよって正しい計算式が空白で区切られても問題ない:Pass
(が終了していない:Pass
文字列を入れると失敗する:Pass
演算記号のみを入れると失敗する:Pass
正解が負の数になっても失敗しない:Pass
変数の定義をしても問題ない:Pass
変数の計算をしても問題ない:Pass
複数の計算を出せる:Pass
Booleanが扱える:Pass
Booleanが扱える(False):Pass
Booleanが扱える(bool同士):Pass
Booleanが混ざった複合演算ができる:Pass
複数分の入ったファイルを読み込んで実行できる:Pass
名前なし関数の実行ができる:Pass
関数内で関数を定義できる:Pass
関数ないで変数を定義できる:Pass
再帰関数を定義できる:Pass
ユークリッドの互除法:Pass
task integration-test  2.63s user 0.57s system 112% cpu 2.832 total
```